### PR TITLE
Improves getValue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,7 @@ type Props = {
 };
 
 function getValue(e: any, { isCheckbox }: { isCheckbox: boolean }) {
-  return e.target ? (isCheckbox ? e.target.checked : e.target.value) : e;
+  return e && e.target ? (isCheckbox ? e.target.checked : e.target.value) : e;
 }
 
 const RHFInput = React.memo(


### PR DESCRIPTION
getValue assumed a parameter would be passed in, but when used with react-select if the Select component tried to clear the value it would call onChange but pass null as the value which would throw an error in getValue.