### PR TITLE
Pass proper input type to register

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -170,6 +170,28 @@ describe('React Hook Form Input', () => {
     expect(register).toBeCalledWith({ name: 'test' }, { required: true });
   });
 
+  it('should register checkbox with correct type', () => {
+    const setValue = () => {};
+    const register = jest.fn();
+    const unregister = () => {};
+    render(
+      <RHFInput
+        setValue={setValue}
+        register={register}
+        unregister={unregister}
+        type="checkbox"
+        name="test"
+        rules={{ required: true }}
+        as="input"
+      />,
+    );
+
+    expect(register).toBeCalledWith(
+      { name: 'test', type: 'checkbox' },
+      { required: true },
+    );
+  });
+
   it('should unregister input when component unmount', () => {
     const setValue = () => {};
     const register = jest.fn();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -95,6 +95,7 @@ const RHFInput = ({
       Object.defineProperty(
         {
           name,
+          type: isCheckbox ? 'checkbox' : undefined,
         },
         'value',
         {


### PR DESCRIPTION
Fixes: https://github.com/react-hook-form/react-hook-form-input/issues/39