### PR TITLE
💪V2 (WIP)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -22,10 +22,6 @@ function getValue(target: any, { isCheckbox }: { isCheckbox: boolean }) {
 }
 
 const RHFInput = ({
-  innerProps,
-  setValue: setValueFromProp,
-  register: registerFromProp,
-  unregister: unregisterFromProp,
   name,
   rules,
   mode = 'onSubmit',
@@ -34,28 +30,22 @@ const RHFInput = ({
   onBlur,
   type,
   value,
-  defaultValue,
-  defaultChecked,
   onChangeName,
   onChangeEvent,
   onBlurName,
   onBlurEvent,
+  control,
   ...rest
 }: Props) => {
   const isCheckbox = type === 'checkbox';
   const isOnChange = mode === 'onChange';
   const isOnBlur = mode === 'onBlur';
-  const defaultData = isCheckbox
-    ? isUndefined(defaultChecked)
-      ? false
-      : defaultChecked
-    : defaultValue;
-  const [inputValue, setInputValue] = React.useState(defaultData);
-  const valueRef = React.useRef(defaultData);
+  const [inputValue, setInputValue] = React.useState(value);
+  const valueRef = React.useRef(value);
   const methods = useFormContext() || {};
-  const setValue = setValueFromProp || methods.setValue;
-  const register = registerFromProp || methods.register;
-  const unregister = unregisterFromProp || methods.unregister;
+  const setValue = control.setValue || methods.setValue;
+  const register = control.register || methods.register;
+  const unregister = control.unregister || methods.unregister;
 
   const commonTask = (target: any) => {
     const data = getValue(target, { isCheckbox });
@@ -114,13 +104,12 @@ const RHFInput = ({
 
     return (): void => {
       if (unregister) {
-        unregister(name as string);
+        unregister(name);
       }
     };
   }, [register, unregister, name]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const props = {
-    ...innerProps,
     ...(onChangeEvent
       ? {
           [onChangeName || 'onChange']: eventWrapper(onChangeEvent, 'onChange'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,9 +33,6 @@ export type EventFunction = (
 export type Props = {
   children?: React.ReactNode;
   innerProps?: any;
-  setValue?: (name: string, value: any, trigger?: boolean) => void;
-  register?: (ref: any, rules: ValidationOptions) => (name: string) => void;
-  unregister?: (name: string) => void;
   name: string;
   as: React.ElementType<any> | React.FunctionComponent<any> | string | any;
   type?: string;
@@ -50,4 +47,5 @@ export type Props = {
   onChangeEvent?: EventFunction;
   onBlurName?: string;
   onBlurEvent?: EventFunction;
+  control: any;
 };


### PR DESCRIPTION
Simplify the API with RHF v4 https://github.com/react-hook-form/react-hook-form/pull/666

```
const { control } = useForm();

<RHFInput as={<ReactSelect />} control={control} />
```

---
The following props will be removed:

1. register
2. unregister
3. setValue
4. mode