### PR TITLE
update RN example to show correct import origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ function App() {
 import * as React from 'react';
 import { View, TextInput, Button } from 'react-native';
 import useForm from 'react-hook-form';
-import { RHFInput } from './index';
+import { RHFInput } from 'react-hook-form-input';
 
 export default () => {
   const { register, setValue, handleSubmit } = useForm();


### PR DESCRIPTION
Minor change to README: Changed the import origin of `RHFInput` to show an import from the package